### PR TITLE
Adds ability to use roles and pass variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Travis-CI
 
 ## Executing Ansible Playbooks
 
-Southbound Ansible execution may be directly invoked by using RPCs.
-To do this you must provide the host, directory, and playbook file to execute.
-To issue an RPC call to localhost, to run a `test.yaml` playbook in `/tmp`:
+Southbound Ansible execution may be directly invoked by using RPCs. Either a playbook can be executed or
+a role directly. To execute a playbook you must provide the host, directory, and playbook file:
+To run a `test.yaml` playbook in `/tmp` on localhost:
 
 `curl -i -u admin:admin -X POST -H "Content-Type: application/json" 127.0.0.1:8181/restconf/operations/ansible-command:run-ansible-command -d '{"input": {"host":"localhost", "directory":"/tmp", "file":"test.yaml"}}'`
 
@@ -23,3 +23,15 @@ This uuid can now be used to query the operational database to see the result of
 In case of a failed command the output from the Ansible Task which failed will also be present:
 
 `{"command":[{"uuid":"75ab1888-c742-46c3-9d77-5fdfe4b22df3","status":"FAILED","failed-event":"\u001b[0;31mfatal: [localhost]: FAILED! => {\"changed\": true, \"cmd\": \"alsjf\", \"delta\": \"0:00:00.002941\", \"end\": \"2018-08-30 15:56:00.770642\", \"failed\": true, \"rc\": 127, \"start\": \"2018-08-30 15:56:00.767701\", \"stderr\": \"/bin/sh: alsjf: command not found\", \"stderr_lines\": [\"/bin/sh: alsjf: command not found\"], \"stdout\": \"\", \"stdout_lines\": []}\u001b[0m"}]}`
+
+Additionally, Ansible variables may be provided which can set things like the SSH user/password for a command:
+
+`curl -u admin:admin -X POST -H "Content-Type: application/json" 127.0.0.1:8181/restconf/operations/ansible-command:run-ansible-command -d '{"input": {"host":"192.168.10.100", "ansible-vars": ["ansible_user=redhat", "ansible_ssh_pass=redhat", "ansible_connection=network_cli", "ansible_network_os=ios"], "directory":"/tmp/test", "file":"test.
+ yaml"}}'`
+ 
+ ## Executing Ansible Roles
+ 
+ In order to execute an Ansible role directly, the `role-name` must be provided, and optionally, any role variables
+ to be set for the role via `role-vars`. For example:
+ 
+`curl -u admin:admin -X POST -H "Content-Type: application/json" 127.0.0.1:8181/restconf/operations/ansible-command:run-ansible-command -d '{"input": {"host":"192.168.10.100", "ansible-vars": ["ansible_user=redhat", "ansible_ssh_pass=redhat", "ansible_connection=network_cli", "ansible_network_os=ios"], "directory":"/tmp/test", "file":"test.yaml"}}'`

--- a/northbound/api/src/main/yang/ansible-command.yang
+++ b/northbound/api/src/main/yang/ansible-command.yang
@@ -40,10 +40,11 @@ module ansible-command {
             description "path to execute";
             type string;
         }
-        leaf file {
-            description "role/playbook to execute";
+        leaf-list ansible-vars {
+            description "extra variables to pass to ansible in a key=value format";
             type string;
         }
+
     }
 
     grouping ansible-command-output {
@@ -63,6 +64,24 @@ module ansible-command {
         description "Run ansible commands.";
         input {
             uses ansible-command-input;
+            choice command-type {
+                case playbook {
+                    leaf file {
+                        description "playbook to execute";
+                        type string;
+                    }
+                }
+                case role {
+                    leaf role-name {
+                        description "role to execute";
+                        type string;
+                    }
+                    leaf-list role-vars {
+                        description "variables to pass into the role written in key=value format";
+                        type string;
+                    }
+                }
+            }
         }
         output {
             uses ansible-command-output;

--- a/southbound/impl/src/test/java/org/opendaylight/ansible/southbound/AnsibleCommandServiceImplTest.java
+++ b/southbound/impl/src/test/java/org/opendaylight/ansible/southbound/AnsibleCommandServiceImplTest.java
@@ -23,6 +23,8 @@ import org.opendaylight.yang.gen.v1.urn.opendaylight.ansible.command.rev180821.A
 import org.opendaylight.yang.gen.v1.urn.opendaylight.ansible.command.rev180821.RunAnsibleCommandInput;
 import org.opendaylight.yang.gen.v1.urn.opendaylight.ansible.command.rev180821.RunAnsibleCommandInputBuilder;
 import org.opendaylight.yang.gen.v1.urn.opendaylight.ansible.command.rev180821.RunAnsibleCommandOutput;
+import org.opendaylight.yang.gen.v1.urn.opendaylight.ansible.command.rev180821.run.ansible.command.input.command.type.Playbook;
+import org.opendaylight.yang.gen.v1.urn.opendaylight.ansible.command.rev180821.run.ansible.command.input.command.type.PlaybookBuilder;
 import org.opendaylight.yangtools.yang.common.RpcResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,9 +41,10 @@ public class AnsibleCommandServiceImplTest {
 
     @Test
     public void testRunAnsibleCommand() throws ExecutionException, InterruptedException {
+        Playbook playbook = new PlaybookBuilder().setFile("file").build();
         RunAnsibleCommandInput input = new RunAnsibleCommandInputBuilder()
             .setDirectory("./src/test/resources")
-            .setFile("file")
+            .setCommandType(playbook)
             .setHost("localhost").build();
         Future<RpcResult<RunAnsibleCommandOutput>> output = ansibleCommandService.runAnsibleCommand(input);
         Assert.assertEquals(output.get().getResult().getStatus(), InProgress);


### PR DESCRIPTION
Previously only support existed for executing playbook files. This patch
adds support to be able to invoke roles directly. Additionally, the
patch exposes the option to set Ansible variables which is useful for
setting per host settings like SSH user/password.

Signed-off-by: Tim Rozet <tdrozet@gmail.com>