### PR TITLE
Adds PE routers as topology nodes

### DIFF
--- a/model/ietf-l3vpn-svc/src/main/yang/l3vpn-svc-aug@2017-05-02.yang
+++ b/model/ietf-l3vpn-svc/src/main/yang/l3vpn-svc-aug@2017-05-02.yang
@@ -111,6 +111,11 @@ module l3vpn-svc-aug {
       description "Provider Edge node-id from network-topology:network-topology/topology/pe/node/<node-id>.";
     }
 
+    leaf ce-node-id {
+      type nt:node-id;
+      description "Customer Equipment node-id";
+    }
+
     leaf pe-2-ce-tp-id {
       type nt:tp-id;
       description "Termination point on Provider Edge which connects Customer Edge.";
@@ -129,26 +134,6 @@ module l3vpn-svc-aug {
     leaf route-policy-out {
       type string;
       description "Route policy name to apply to outbound routes.";
-    }
-
-    leaf username {
-        type string;
-        description "login username.";
-    }
-
-    leaf password {
-        type string;
-        description "login password.";
-    }
-
-    leaf device-type {
-        type string;
-        description "The hardware device type.";
-    }
-
-    leaf pe-mgmt-ip {
-        type inet:ipv4-address;
-        description "Address for control plane management of the PE device";
     }
   }
 

--- a/northbound/api/pom.xml
+++ b/northbound/api/pom.xml
@@ -36,6 +36,11 @@ and is available at http://www.eclipse.org/legal/epl-v10.html
             <groupId>org.opendaylight.mdsal.model</groupId>
             <artifactId>ietf-topology</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.7</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -48,7 +53,8 @@ and is available at http://www.eclipse.org/legal/epl-v10.html
                     <instructions>
                         <Export-Package>
                             org.opendaylight.ansible.northbound.api,
-                            org.opendaylight.yang.gen.v1.urn.opendaylight.ansible.*
+                            org.opendaylight.yang.gen.v1.urn.opendaylight.ansible.*,
+                            org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.aug.*
                         </Export-Package>
                     </instructions>
                 </configuration>

--- a/northbound/api/src/main/java/org/opendaylight/ansible/northbound/api/AnsibleTopology.java
+++ b/northbound/api/src/main/java/org/opendaylight/ansible/northbound/api/AnsibleTopology.java
@@ -8,15 +8,37 @@
 
 package org.opendaylight.ansible.northbound.api;
 
+import com.google.common.base.Optional;
+import java.util.List;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.opendaylight.ansible.mdsalutils.Datastore;
+import org.opendaylight.ansible.mdsalutils.SingleTransactionDataBroker;
+import org.opendaylight.ansible.mdsalutils.TypedReadWriteTransaction;
+import org.opendaylight.controller.md.sal.binding.api.DataBroker;
+import org.opendaylight.controller.md.sal.common.api.data.LogicalDatastoreType;
+import org.opendaylight.controller.md.sal.common.api.data.ReadFailedException;
 import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.NetworkTopology;
+import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.NodeId;
 import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.TopologyId;
+import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.TpId;
+import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.link.attributes.Destination;
+import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.link.attributes.DestinationBuilder;
+import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.link.attributes.Source;
+import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.link.attributes.SourceBuilder;
 import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.network.topology.Topology;
 import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.network.topology.TopologyKey;
+import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.network.topology.topology.Link;
+import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.network.topology.topology.LinkKey;
 import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.network.topology.topology.Node;
+import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.network.topology.topology.NodeKey;
 import org.opendaylight.yangtools.yang.binding.InstanceIdentifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class AnsibleTopology {
-    public static final TopologyId ANSIBLE_TOPOLOGY_ID = new TopologyId("ansible:1");
+    public static final TopologyId ANSIBLE_TOPOLOGY_ID = new TopologyId("flow:1");
+    private static final Logger LOG = LoggerFactory.getLogger(AnsibleTopology.class);
 
     private AnsibleTopology() {}
 
@@ -28,5 +50,108 @@ public final class AnsibleTopology {
             .child(Topology.class, new TopologyKey(ANSIBLE_TOPOLOGY_ID))
             .child(Node.class);
 
+    public static final InstanceIdentifier<Link> ANSIBLE_LINK_PATH =
+            InstanceIdentifier.create(NetworkTopology.class)
+                    .child(Topology.class, new TopologyKey(ANSIBLE_TOPOLOGY_ID))
+                    .child(Link.class);
 
+    public static Node getNode(NodeId nodeId, DataBroker dataBroker) {
+        InstanceIdentifier<Node> nodePath = InstanceIdentifier.create(NetworkTopology.class)
+                .child(Topology.class, new TopologyKey(ANSIBLE_TOPOLOGY_ID))
+                .child(Node.class, new NodeKey(nodeId));
+        Node node = null;
+        try {
+            Optional<Node> optionalNode = SingleTransactionDataBroker.syncReadOptional(dataBroker,
+                    LogicalDatastoreType.OPERATIONAL, nodePath);
+            if (optionalNode.isPresent()) {
+                node = optionalNode.get();
+            }
+        } catch (ReadFailedException e) {
+            LOG.warn("Read exception...Unable to find matching topology node: {}", nodeId);
+        }
+
+        return node;
+    }
+
+    public static void populateLink(Link link, Boolean remove, TypedReadWriteTransaction<? extends Datastore> tx) {
+        InstanceIdentifier<Link> linkPath = InstanceIdentifier.create(NetworkTopology.class)
+                .child(Topology.class, new TopologyKey(ANSIBLE_TOPOLOGY_ID))
+                .child(Link.class, new LinkKey(link.getLinkId()));
+        if (remove) {
+            LOG.info("Removing link: {}", link.getLinkId());
+            tx.delete(linkPath);
+        } else {
+            LOG.info("Adding new link: {}", link.getLinkId());
+            tx.put(linkPath, link, true);
+        }
+    }
+
+    public static List<Link> getLinks(DataBroker dataBroker) {
+        InstanceIdentifier<Topology> topologyPath = InstanceIdentifier.create(NetworkTopology.class)
+                .child(Topology.class, new TopologyKey(ANSIBLE_TOPOLOGY_ID));
+        List<Link> links = null;
+        try {
+            Optional<Topology> optionalTopo = SingleTransactionDataBroker.syncReadOptional(dataBroker,
+                    LogicalDatastoreType.OPERATIONAL, topologyPath);
+            if (optionalTopo.isPresent()) {
+                links = optionalTopo.get().getLink();
+            }
+        } catch (ReadFailedException e) {
+            LOG.warn("Read exception...Unable to find links in topology");
+        }
+        return links;
+    }
+
+    public static Source getLinkSource(Destination dest, DataBroker dataBroker) {
+        List<Link> links = getLinks(dataBroker);
+        if (links == null) {
+            return null;
+        }
+        for (Link link : links) {
+            if (link.getDestination().equals(dest)) {
+                LOG.info("Matching Source link found for link: {}", link.getLinkId().getValue());
+                return link.getSource();
+            }
+        }
+        LOG.info("Did not find any matching source links for dest link node: {}, interface: {}",
+                dest.getDestNode().getValue(), dest.getDestTp().getValue());
+        return null;
+    }
+
+    public static Destination getLinkDest(Source source, DataBroker dataBroker) {
+        List<Link> links = getLinks(dataBroker);
+        if (links == null) {
+            return null;
+        }
+        for (Link link : links) {
+            if (link.getSource().equals(source)) {
+                LOG.info("Matching Source link found for link: {}", link.getLinkId().getValue());
+                return link.getDestination();
+            }
+        }
+        LOG.info("Did not find any matching dest links for source link node: {}, interface: {}",
+                source.getSourceNode().getValue(), source.getSourceTp().getValue());
+        return null;
+    }
+
+    public static Pair<NodeId, TpId> getLinkPeer(NodeId nodeId, TpId tpId, DataBroker dataBroker) {
+        // method searches for a link peer, returns the node Id and Tp ID
+        // try to search first for links that match destination
+        Destination origDest = new DestinationBuilder().setDestNode(nodeId)
+                .setDestTp(tpId).build();
+        Source source = getLinkSource(origDest, dataBroker);
+        if (source != null) {
+            return new ImmutablePair<>(source.getSourceNode(), source.getSourceTp());
+        }
+        // searching for links that matched dest failed, now search for source
+        Source origSource = new SourceBuilder().setSourceNode(nodeId)
+                .setSourceTp(tpId).build();
+        Destination dest = getLinkDest(origSource, dataBroker);
+        if (dest != null) {
+            return new ImmutablePair<>(dest.getDestNode(), dest.getDestTp());
+        }
+        // If we get here we did not find any links for this node id and tpid
+        LOG.warn("Unable to find any links with nodeid: {}, and tpid: {}", nodeId.getValue(), tpId.getValue());
+        return null;
+    }
 }

--- a/northbound/api/src/main/yang/network-topology-aug@2018-10-15.yang
+++ b/northbound/api/src/main/yang/network-topology-aug@2018-10-15.yang
@@ -1,0 +1,72 @@
+module network-topology-aug {
+  yang-version 1;
+  namespace "urn:TBD:params:xml:ns:yang:network-topology-aug";
+
+  prefix "network-topology-aug";
+
+  import yang-ext {
+    prefix ext;
+    revision-date "2013-07-09";
+  }
+
+  import ietf-inet-types {
+    prefix inet;
+  }
+
+  import network-topology {
+    prefix nt;
+    revision-date 2013-10-21;
+  }
+
+  organization "TBD";
+
+  contact "WILL-BE-DEFINED-LATER";
+
+  description
+          "This module defines a model for the topology of a network.
+          Key design decisions are as follows:
+          A topology consists of a set of nodes and links.
+          Links are point-to-point and unidirectional.
+          Bidirectional connections need to be represented through
+          two separate links.
+          Multipoint connections, broadcast domains etc can be represented
+          through a hierarchy of nodes, then connecting nodes at
+          upper layers of the hierarchy.";
+
+  revision 2018-10-15 {
+    description
+      "Initial revision.";
+  }
+
+  grouping node-mgmt-attributes {
+    description
+      "Attributes for an ansible node type";
+
+    leaf username {
+        type string;
+        description "login username.";
+    }
+
+    leaf password {
+        type string;
+        description "login password.";
+    }
+
+    leaf device-type {
+        type string;
+        description "The hardware device type.";
+    }
+
+    leaf pe-mgmt-ip {
+        type inet:ipv4-address;
+        description "Address for control plane management of the PE device";
+    }
+  }
+
+  augment "nt:network-topology/nt:topology/nt:node" {
+    description "Augments node with management info";
+    ext:augment-identifier "mgmt-augmentation";
+
+    uses node-mgmt-attributes;
+  }
+}

--- a/northbound/impl/src/main/java/org/opendaylight/ansible/northbound/AnsibleLinkListener.java
+++ b/northbound/impl/src/main/java/org/opendaylight/ansible/northbound/AnsibleLinkListener.java
@@ -9,7 +9,7 @@
 package org.opendaylight.ansible.northbound;
 
 import static org.opendaylight.ansible.mdsalutils.Datastore.OPERATIONAL;
-import static org.opendaylight.ansible.northbound.api.AnsibleTopology.ANSIBLE_NODE_PATH;
+import static org.opendaylight.ansible.northbound.api.AnsibleTopology.ANSIBLE_LINK_PATH;
 
 import com.google.common.base.Optional;
 import javax.annotation.Nonnull;
@@ -25,15 +25,15 @@ import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.
 import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.TopologyId;
 import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.network.topology.Topology;
 import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.network.topology.TopologyKey;
-import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.network.topology.topology.Node;
+import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.network.topology.topology.Link;
 import org.opendaylight.yangtools.yang.binding.InstanceIdentifier;
 import org.ops4j.pax.cdi.api.OsgiService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Singleton
-public class AnsibleNodeListener extends AbstractSyncDataTreeChangeListener<Node> {
-    private static final Logger LOG = LoggerFactory.getLogger(AnsibleNodeListener.class);
+public class AnsibleLinkListener extends AbstractSyncDataTreeChangeListener<Link> {
+    private static final Logger LOG = LoggerFactory.getLogger(AnsibleLinkListener.class);
     private final RetryingManagedNewTransactionRunner txRunner;
     private DataBroker dataBroker;
     private TopologyId flowId = new TopologyId("flow:1");
@@ -41,43 +41,43 @@ public class AnsibleNodeListener extends AbstractSyncDataTreeChangeListener<Node
             Topology.class, new TopologyKey(flowId));
 
     @Inject
-    public AnsibleNodeListener(@OsgiService final DataBroker dataBroker) {
-        super(dataBroker, LogicalDatastoreType.CONFIGURATION, ANSIBLE_NODE_PATH);
+    public AnsibleLinkListener(@OsgiService final DataBroker dataBroker) {
+        super(dataBroker, LogicalDatastoreType.CONFIGURATION, ANSIBLE_LINK_PATH);
         LOG.info("constructor");
         this.txRunner = new RetryingManagedNewTransactionRunner(dataBroker);
         this.dataBroker = dataBroker;
     }
 
     @Override
-    public void add(@Nonnull InstanceIdentifier<Node> instanceIdentifier, @Nonnull Node node) {
+    public void add(@Nonnull InstanceIdentifier<Link> instanceIdentifier, @Nonnull Link node) {
         LOG.info("add: id: {}\nnode: {}", instanceIdentifier, node);
         try {
-            Optional<Node> myNode = SingleTransactionDataBroker.syncReadOptional(dataBroker,
+            Optional<Link> myLink = SingleTransactionDataBroker.syncReadOptional(dataBroker,
                     LogicalDatastoreType.CONFIGURATION, instanceIdentifier);
-            if (myNode.isPresent()) {
-                LOG.info("Node found in configuration datastore");
+            if (myLink.isPresent()) {
+                LOG.info("Link found in configuration datastore");
 
                 txRunner.callWithNewReadWriteTransactionAndSubmit(OPERATIONAL, tx -> {
-                    tx.put(instanceIdentifier, myNode.get());
-                    LOG.info("Node written to oper: {}", myNode.get().getNodeId().getValue());
+                    tx.put(instanceIdentifier, myLink.get());
+                    LOG.info("Link written to oper: {}", myLink.get().getLinkId().getValue());
                 });
             } else {
-                LOG.error("Failed to read topology node from configuration during add");
+                LOG.error("Failed to read topology link from configuration during add");
             }
 
         } catch (ReadFailedException e) {
-            LOG.error("Error reading ansible node during add");
+            LOG.error("Error reading ansible link during add");
         }
     }
 
     @Override
-    public void remove(@Nonnull InstanceIdentifier<Node> instanceIdentifier, @Nonnull Node node) {
-        LOG.info("remove: id: {}\nnode: {}", instanceIdentifier, node);
+    public void remove(@Nonnull InstanceIdentifier<Link> instanceIdentifier, @Nonnull Link node) {
+        LOG.info("remove: id: {}\nlink: {}", instanceIdentifier, node);
     }
 
     @Override
-    public void update(@Nonnull InstanceIdentifier<Node> instanceIdentifier,
-                       @Nonnull Node oldNode, @Nonnull Node newNode) {
-        LOG.info("update: id: {}\nold node: {}\nold node: {}", instanceIdentifier, oldNode, newNode);
+    public void update(@Nonnull InstanceIdentifier<Link> instanceIdentifier,
+                       @Nonnull Link oldNode, @Nonnull Link newNode) {
+        LOG.info("update: id: {}\nold link: {}\nold link: {}", instanceIdentifier, oldNode, newNode);
     }
 }

--- a/southbound/impl/src/main/java/org/opendaylight/ansible/southbound/StatusL3vpnListener.java
+++ b/southbound/impl/src/main/java/org/opendaylight/ansible/southbound/StatusL3vpnListener.java
@@ -29,13 +29,17 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import org.opendaylight.ansible.mdsalutils.Datastore;
 import org.opendaylight.ansible.mdsalutils.RetryingManagedNewTransactionRunner;
 import org.opendaylight.ansible.mdsalutils.SingleTransactionDataBroker;
+import org.opendaylight.ansible.mdsalutils.TypedReadWriteTransaction;
+import org.opendaylight.ansible.northbound.api.AnsibleTopology;
 import org.opendaylight.ansible.northbound.api.IetfL3vpnSvcUtils;
 import org.opendaylight.controller.md.sal.binding.api.DataBroker;
 import org.opendaylight.controller.md.sal.common.api.data.LogicalDatastoreType;
@@ -45,6 +49,7 @@ import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.inet.types.
 import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.l3vpn.svc.rev170502.L3vpnSvc;
 import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.l3vpn.svc.rev170502.Status;
 import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.l3vpn.svc.rev170502.StatusL3vpnProvider;
+import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.l3vpn.svc.rev170502.access.vpn.policy.vpn.attachment.attachment.flavor.VpnId;
 import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.l3vpn.svc.rev170502.l3vpn.svc.fields.Sites;
 import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.l3vpn.svc.rev170502.l3vpn.svc.fields.VpnServices;
 import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.l3vpn.svc.rev170502.l3vpn.svc.fields.sites.Site;
@@ -54,6 +59,17 @@ import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.yang.types.
 import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.l3vpn.svc.aug.rev170502.PeAugmentation;
 import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.l3vpn.svc.aug.rev170502.VrfAugmentation;
 import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.l3vpn.svc.aug.rev170502.VrfName;
+import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.aug.rev181015.MgmtAugmentation;
+import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.LinkId;
+import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.NodeId;
+import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.TpId;
+import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.link.attributes.Destination;
+import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.link.attributes.DestinationBuilder;
+import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.link.attributes.Source;
+import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.link.attributes.SourceBuilder;
+import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.network.topology.topology.Link;
+import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.network.topology.topology.LinkBuilder;
+import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.network.topology.topology.Node;
 import org.opendaylight.yangtools.yang.binding.InstanceIdentifier;
 import org.ops4j.pax.cdi.api.OsgiService;
 import org.slf4j.Logger;
@@ -70,6 +86,8 @@ public class StatusL3vpnListener extends AbstractSyncDataTreeChangeListener<Stat
     private ListeningExecutorService executor;
     private static ListenableFuture<List<Uuid>> l3vpnCommands;
     private Map<String, String> routeTargets = new HashMap<>();
+    // Pe to VPN hashmap
+    private Map<PeAugmentation, String> vpnLinks = new ConcurrentHashMap<>();
 
     private enum State {
         PRESENT,
@@ -227,9 +245,12 @@ public class StatusL3vpnListener extends AbstractSyncDataTreeChangeListener<Stat
                             IetfL3vpnSvcUtils.putStatusL3VPN(tx, COMMIT_VERSION, Status.Failed)
                     );
                 } else {
-                    txRunner.callWithNewReadWriteTransactionAndSubmit(OPERATIONAL, tx ->
-                            IetfL3vpnSvcUtils.putStatusL3VPN(tx, COMMIT_VERSION, Status.Complete)
-                    );
+                    txRunner.callWithNewReadWriteTransactionAndSubmit(OPERATIONAL, tx -> {
+                        LOG.info("L3VPN COMPLETE");
+                        IetfL3vpnSvcUtils.putStatusL3VPN(tx, COMMIT_VERSION, Status.Complete);
+                        LOG.info("Updating VPN links");
+                        updateVpnLink(tx, state, vpnServiceList.get(0).getVpnId().getValue());
+                    });
                 }
             } catch (InterruptedException | ExecutionException e) {
                 txRunner.callWithNewReadWriteTransactionAndSubmit(OPERATIONAL, tx ->
@@ -310,13 +331,26 @@ public class StatusL3vpnListener extends AbstractSyncDataTreeChangeListener<Stat
                 "l3vpn_sites=" + roleSiteVar
                 );
 
+        // Find topology node for this site
+        NodeId nodeId = sitePeAccess.getPeNodeId();
+        if (nodeId == null) {
+            LOG.error("Missing PE node ID in site configuration for site: {}", site);
+            throw new L3vpnConfigException("PE topology node ID missing in site configuration");
+        }
+        Node siteNode = AnsibleTopology.getNode(nodeId, dataBroker);
+        if (siteNode == null) {
+            LOG.error("Unable to find matching topology node: {} specified for site: {}", nodeId, site);
+            throw new L3vpnConfigException("Cannot find topology node for PE in site");
+        }
+
         LOG.info("Role vars are: {}", roleVars);
-        Ipv4Address peMgmtIp = sitePeAccess.getPeMgmtIp();
+        MgmtAugmentation siteMgmt = siteNode.augmentation(MgmtAugmentation.class);
+        Ipv4Address peMgmtIp = siteMgmt.getPeMgmtIp();
         if (peMgmtIp == null) {
             LOG.error("Missing site management IP address for site: {}", site);
             throw new L3vpnConfigException("Site management IP address is missing");
         }
-        deviceType = sitePeAccess.getDeviceType();
+        deviceType = siteMgmt.getDeviceType();
         if (deviceType == null) {
             LOG.error("Missing device type for site: {}", site);
             throw new L3vpnConfigException("Device type not specified for site");
@@ -329,8 +363,8 @@ public class StatusL3vpnListener extends AbstractSyncDataTreeChangeListener<Stat
             networkOS = "eos";
         }
         ansibleVars = Arrays.asList(
-                "ansible_user=" + sitePeAccess.getUsername(),
-                "ansible_ssh_pass=" + sitePeAccess.getPassword(),
+                "ansible_user=" + siteMgmt.getUsername(),
+                "ansible_ssh_pass=" + siteMgmt.getPassword(),
                 "ansible_connection=network_cli",
                 "ansible_network_os=" + networkOS,
                 "ansible_network_provider=" + provider,
@@ -350,6 +384,11 @@ public class StatusL3vpnListener extends AbstractSyncDataTreeChangeListener<Stat
         return  executor.submit(() -> {
             while (!ansibleCommandService.isAnsibleComplete(siteCmdId)) {}
             if (ansibleCommandService.ansibleCommandSucceeded(siteCmdId)) {
+                String vpnId = ((VpnId) access.get(0).getVpnAttachment().getAttachmentFlavor()).getVpnId().getValue();
+                LOG.info("PE attachment for site {}, added to vpnlinks map for vpn: {}", site.getSiteId().getValue(),
+                        vpnId);
+                vpnLinks.put(sitePeAccess, vpnId);
+
                 return siteCmdId;
             } else {
                 return null;
@@ -371,5 +410,87 @@ public class StatusL3vpnListener extends AbstractSyncDataTreeChangeListener<Stat
             rt = randomRdRt();
         }
         routeTargets.put(vrfAug.getVrfName().getValue(), rt);
+    }
+
+    private void updateVpnLink(TypedReadWriteTransaction<? extends Datastore> tx, State state, String vpnId) {
+        // iterate vpn links hash map, find links that apply the current vpn, build link, update oper
+        LOG.info("In updating vpn link");
+        Link vpnLink;
+        Boolean remove = false;
+        NodeId ceNodeId;
+        // assuming here there is only 2 endpoints for a vpn for now
+        PeAugmentation peAug;
+        Source vpnSource;
+        Destination vpnDest;
+        LOG.info("Polling for vpn links now...");
+        for (ConcurrentHashMap.Entry<PeAugmentation, String> linkEntry : vpnLinks.entrySet()) {
+            if (linkEntry.getValue().equals(vpnId)) {
+                peAug = linkEntry.getKey();
+                ceNodeId = peAug.getCeNodeId();
+                LOG.info("Detected vpn PE link endpoint. Searching for CE node with id: {}", ceNodeId.getValue());
+                Node ceNode = AnsibleTopology.getNode(ceNodeId, dataBroker);
+                if (ceNode == null) {
+                    LOG.error("Unable to find CE node, will not update Topology");
+                    return;
+                }
+                // assume CE only has 1 interface
+                TpId ceTpId = ceNode.getTerminationPoint().get(0).getTpId();
+                if (ceTpId == null) {
+                    LOG.error("Unable to find CE TpId, will not update Topology");
+                    return;
+                }
+                LOG.info("Building new link for VPN between PE: {}, and CE: {}", peAug.getPeNodeId().getValue(),
+                        ceNodeId.getValue());
+                vpnSource = new SourceBuilder().setSourceTp(ceTpId).setSourceNode(ceNodeId).build();
+                vpnDest = new DestinationBuilder().setDestTp(peAug.getPe2CeTpId()).setDestNode(peAug.getPeNodeId())
+                        .build();
+                vpnLink = new LinkBuilder().setLinkId(new LinkId(ceNodeId.getValue())).setSource(vpnSource)
+                        .setDestination(vpnDest).build();
+                if (state == State.ABSENT) {
+                    remove = true;
+                    LOG.info("Removing previous VPN link between customer sites: {}", vpnLink.getLinkId().getValue());
+                } else {
+                    LOG.info("Populating new VPN link between customer sites: {}", vpnLink.getLinkId().getValue());
+                }
+                AnsibleTopology.populateLink(vpnLink, remove, tx);
+            }
+        }
+        LOG.info("Topology update complete for VPN: {}", vpnId);
+        /**
+         * The below was used to detect and create a VPN link between customer sites. It didn't show up well in the GUI
+         * when representing a an MPLS VPN, but it could be used in the future for building a point to point link
+         * between VPN sites
+        LOG.info("Finished vpnlink detection");
+        // This builds the CE source side of the link
+        ceSource = AnsibleTopology.getLinkPeer(peSource.getPeNodeId(), peSource.getPe2CeTpId(), dataBroker);
+        if (ceSource == null) {
+            LOG.error("Unable to determine CE source side of the link, will not update Topology");
+            return;
+        }
+        // Find the CE dest side of the link
+        ceDest = AnsibleTopology.getLinkPeer(peDest.getPeNodeId(), peDest.getPe2CeTpId(), dataBroker);
+        if (ceDest == null) {
+            LOG.error("Unable to determine CE dest side of the link, will not update Topology");
+            return;
+        }
+
+        // Found both sides of the link, build new link object
+        LOG.info("Topology updater: links for customer equipment found");
+        Source vpnSource = new SourceBuilder().setSourceTp(ceSource.getValue())
+                .setSourceNode(ceSource.getKey()).build();
+
+        Destination vpnDest = new DestinationBuilder().setDestNode(ceDest.getKey())
+                .setDestTp(ceDest.getValue()).build();
+
+        vpnLink = new LinkBuilder().setLinkId(new LinkId(vpnId)).setSource(vpnSource)
+                .setDestination(vpnDest).build();
+        if (state == State.ABSENT) {
+            remove = true;
+            LOG.info("Removing previous VPN link between customer sites: {}", vpnLink.getLinkId().getValue());
+        } else {
+            LOG.info("Populating new VPN link between customer sites: {}", vpnLink.getLinkId().getValue());
+        }
+        AnsibleTopology.populateLink(vpnLink, remove, tx);
+         **/
     }
 }


### PR DESCRIPTION
Now nodes will be registered as topology nodes. When creating L3VPN the
sites will no longer contain the node information, and instead
reference a node-id which will reference a node in topology.

Signed-off-by: Tim Rozet <tdrozet@gmail.com>